### PR TITLE
Fix white overlay on small screens

### DIFF
--- a/app/assets/sass/settings.scss
+++ b/app/assets/sass/settings.scss
@@ -1,0 +1,2 @@
+$govuk-canvas-background-colour: #1E1F21;
+


### PR DESCRIPTION
It's not clear from [this issue](https://github.com/alphagov/dsp-dashboard/issues/18), but it looks like smaller screens are showing a whitish overlay.

Setting very narrow screen widths in chrome shows something similar.

It looks like cause is GOVUK frontend's long footer, see

https://github.com/alphagov/govuk-frontend/blob/680b8d5baa4cbf35ff0f38afdc62d758e2a61f0c/packages/govuk-frontend/src/govuk/objects/_template.scss#L8

This commit adds a settings file to override the colour, using the background colour found in application.scss.

It would probably be best to extract the colour definitions into their own sass file, so the value could be referenced in both places.

Another alternative would be to use the GOVUK colour variables.

I'm not sure it matters too much here though.