### PR TITLE
Use Github API to fetch Pay data

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -9,7 +9,8 @@ router.get('/', async (req, res) => {
   res.locals.month = date.toLocaleString('default', { month: 'long' })
   res.locals.year = date.getFullYear()
 
-  const payData = await fetchData('https://raw.githubusercontent.com/alphagov/pay-product-page/refs/heads/main/data/performance.json', 'payDataCache')
+  const rawPayData = await fetchData('https://api.github.com/repos/alphagov/pay-product-page/contents/data/performance.json?ref=main', 'payDataCache')
+  const payData = JSON.parse(Buffer.from(rawPayData['content'], "base64").toString("utf-8"))
 
   let totalPaymentAmount = payData['totalPaymentAmount'].replace('billion', 'B')
   res.locals.totalPaymentAmount = totalPaymentAmount


### PR DESCRIPTION
If you use Github’s CDN they might eventually rate limit you and things will stop working in an unexpected way.

On Notify<sup>1</sup> We've seen issues where `raw.githubusercontent.com` has returned `403`s, possibly due to some kind of WAF on github's web cache that is blocking our requests.

We can instead use github's API<sup>2</sup> to get the same data in a more expected way. Note that it doesn't need auth for public repos, but you get more lenient rate limits with auth. So far on Notify we haven’t had to do this.

***

1. https://github.com/alphagov/notifications-utils/commit/f7f12c421f93041cb4447ae67ce1a6fb5998e9b2
2. https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content