### PR TITLE
Use tabular numbers for big numbers

### DIFF
--- a/app/assets/sass/_big-number.scss
+++ b/app/assets/sass/_big-number.scss
@@ -10,7 +10,7 @@
 }
 
 .gem-c-big-number__value {
-  @include govuk-font($size: false, $weight: bold);
+  @include govuk-font($size: false, $weight: bold, $tabular: true);
   line-height: 1;
   font-size: 80px;
   font-size: govuk-px-to-rem(75px);


### PR DESCRIPTION
Tabular numbers (as opposed to proportional or lining) are where each character takes up the same amount of horizontal space.

Generally I think they look better when used on dashboards, for example in the blue boxes on a Notify dashboard:

<img width="755" alt="image" src="https://github.com/user-attachments/assets/e7f69616-3a05-4cda-84c2-4aaf94e89a5c" />

It also means if the numbers ever change dynamically things don’t jump around as much.

***

Before | After
---|---
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/bc6b219b-5483-4bbb-8dee-79d9fa6ca537" /> | <img width="999" alt="image" src="https://github.com/user-attachments/assets/a04e7e20-492a-469f-a283-636c78ca66f0" />