### PR TITLE
Refresh the page every hour

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -193,3 +193,15 @@
   #}
 
   {% endblock %}
+
+  {% block bodyEnd %}
+    <script>
+      setTimeout(
+        function(){
+          window.location.reload();
+        },
+        // hours * minutes * seconds * milliseconds
+        1 * 60 * 60 * 1000
+      );
+    </script>
+  {% endblock %}


### PR DESCRIPTION
So it always has the latest data.

An hour seems sensible since most of the data is updated on an ad-hoc basis.

Can’t use a `<meta refresh … >` tag because the prototype kit breaks if you try to override the `head` block in the GOV.UK Template.