### PR TITLE
Make spacing between numbers and metric suffix consistent

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -11,15 +11,15 @@ router.get('/', async (req, res) => {
 
   const payData = await fetchData('https://raw.githubusercontent.com/alphagov/pay-product-page/refs/heads/main/data/performance.json', 'payDataCache')
 
-  let totalPaymentAmount = payData['totalPaymentAmount'].replace('billion', 'B')
+  let totalPaymentAmount = payData['totalPaymentAmount'].replace(' billion', '&hairsp;B')
   res.locals.totalPaymentAmount = totalPaymentAmount
-  res.locals.numberOfPayments = payData['numberOfPayments'].replace('million', 'M')
+  res.locals.numberOfPayments = payData['numberOfPayments'].replace(' million', '&hairsp;M')
   res.locals.payNumberOfServices = payData['numberOfServices']
   res.locals.payNumberOfOrganisations = payData['numberOfOrganisations']
 
   const notifyData = await fetchData('https://www.notifications.service.gov.uk/features/performance.json', 'notifyDataCache')
 
-  res.locals.notifyTotalMsgs = (notifyData['total_notifications'] / 1e9).toFixed(1) + "B"
+  res.locals.notifyTotalMsgs = (notifyData['total_notifications'] / 1e9).toFixed(1) + "&hairsp;B"
   res.locals.notifyLive = notifyData['count_of_live_services_and_organisations']['services']
   res.locals.notifyOrgs = notifyData['count_of_live_services_and_organisations']['organisations']
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -15,7 +15,7 @@
       <div class="gem-c-big-numbers">
         <div class="gem-c-big-number govuk-!-margin-bottom-8">
           <span class="gem-c-big-number__value">
-            £{{ totalPaymentAmount }}
+            £{{ totalPaymentAmount|safe }}
           </span>
           <span class="govuk-visually-hidden">&nbsp;</span>
           <span class="gem-c-big-number__label">
@@ -24,7 +24,7 @@
         </div>
         <div class="gem-c-big-number govuk-!-margin-bottom-8">
           <span class="gem-c-big-number__value">
-            {{ numberOfPayments }}
+            {{ numberOfPayments|safe }}
           </span>
           <span class="govuk-visually-hidden">&nbsp;</span>
           <span class="gem-c-big-number__label">
@@ -102,7 +102,7 @@
       <div class="gem-c-big-numbers">
         <div class="gem-c-big-number govuk-!-margin-bottom-8">
           <span class="gem-c-big-number__value">
-            £27M
+            £27&hairsp;M
           </span>
           <span class="govuk-visually-hidden">&nbsp;</span>
           <span class="gem-c-big-number__label">
@@ -111,7 +111,7 @@
         </div>
         <div class="gem-c-big-number govuk-!-margin-bottom-8">
           <span class="gem-c-big-number__value">
-            {{ notifyTotalMsgs }}
+            {{ notifyTotalMsgs|safe }}
           </span>
           <span class="govuk-visually-hidden">&nbsp;</span>
           <span class="gem-c-big-number__label">
@@ -145,7 +145,7 @@
 
         <div class="gem-c-big-number govuk-!-margin-bottom-8">
           <span class="gem-c-big-number__value">
-            £38M
+            £38&hairsp;M
           </span>
           <span class="govuk-visually-hidden">&nbsp;</span>
           <span class="gem-c-big-number__label">
@@ -163,7 +163,7 @@
         </div>
         <div class="gem-c-big-number govuk-!-margin-bottom-8">
           <span class="gem-c-big-number__value">
-            11.5M
+            11.5&hairsp;M
           </span>
           <span class="govuk-visually-hidden">&nbsp;</span>
           <span class="gem-c-big-number__label">


### PR DESCRIPTION
In some cases there was a space and some not.

This commit standardises on always having a very small space (a hair’s width) between them.

This gives a little bit of visual separation while still visually grouping it with the associated numerals.

Before | After
---|---
<img width="323" alt="image" src="https://github.com/user-attachments/assets/785e5465-e504-4de0-8b1c-7598f4b7f106" /> | <img width="359" alt="image" src="https://github.com/user-attachments/assets/522dfa5b-864e-4c5d-bc58-54ea9ae6da05" />
